### PR TITLE
Update to room-2.4.1 for m1 chips

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         gradle_version = '7.0.3'
         kotlin_version = '1.5.31'
         hilt_version = '2.39.1'
-        room_version = '2.3.0'
+        room_version = '2.4.1'
         compose_version = '1.0.5'
     }
     repositories {


### PR DESCRIPTION
room 2.4.0-alpha03 fix an issue Room’s SQLite native library to support Apple’s M1 chips. [link](https://developer.android.com/jetpack/androidx/releases/room#:~:text=Fixed%20an%20issue%20with%20Room%E2%80%99s%20SQLite%20native%20library%20to%20support%20Apple%E2%80%99s%20M1%20chips.)