### PR TITLE
UI improvement

### DIFF
--- a/app/src/main/java/io/github/devriesl/raptormark/data/SettingOptions.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/data/SettingOptions.kt
@@ -247,6 +247,7 @@ enum class SettingOptions(
             return {
                 SingleChoiceDialog(
                     title = IO_ENGINE.title,
+                    defaultChoice = settingSharedPrefs.getConfig(IO_ENGINE.name, DEFAULT_IO_ENGINE_VALUE),
                     choiceList = engineList,
                     itemIndex = itemIndex,
                     closeDialog = closeDialog

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/AppDrawer.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/AppDrawer.kt
@@ -2,18 +2,18 @@ package io.github.devriesl.raptormark.ui
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.Image
+import androidx.compose.foundation.*
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -48,27 +48,47 @@ private fun DrawerButton(
     action: () -> Unit
 ) {
     val color = if (isSelected) {
-        MaterialTheme.colors.secondary
+        MaterialTheme.colors.primary
     } else {
         LocalContentColor.current
     }
-
-    TextButton(
-        onClick = action,
+    val mutableInteractionSource = remember {
+        MutableInteractionSource()
+    }
+    val shape = MaterialTheme.shapes.small
+    Surface(
+        color = Color.Transparent,
+        contentColor = color,
         modifier = Modifier.fillMaxWidth()
+            .clickable(
+                indication = null,
+                interactionSource = mutableInteractionSource,
+                onClick = action
+            )
     ) {
         Row(
             horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
+                .padding(
+                    horizontal = 8.dp,
+                    vertical = 4.dp
+                )
+                .defaultMinSize(minHeight = 40.dp)
+                .background(
+                    color = if (isSelected) color.copy(0.12f) else Color.Transparent,
+                    shape = shape
+                )
+                .clip(shape)
+                .indication(mutableInteractionSource, LocalIndication.current)
         ) {
-            Image(
+            Icon(
                 painter = painterResource(icon),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(color)
+                modifier = Modifier.padding(start = 8.dp)
             )
             Spacer(Modifier.width(16.dp))
-            Text(text = stringResource(title), color = color)
+            Text(text = stringResource(title), style = MaterialTheme.typography.body2)
         }
     }
 }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/AppTopBar.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/AppTopBar.kt
@@ -1,31 +1,14 @@
 package io.github.devriesl.raptormark.ui
 
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.res.stringResource
 import io.github.devriesl.raptormark.R
 
 @Composable
-fun AppTopBar(
-    openDrawer: () -> Unit
-) {
+fun AppTopBar() {
     TopAppBar(
         title = { Text(text = stringResource(id = R.string.app_name)) },
-        actions = {
-            CompositionLocalProvider {
-                IconButton(onClick = { openDrawer() }) {
-                    Icon(
-                        imageVector = Icons.Filled.Menu,
-                        contentDescription = null
-                    )
-                }
-            }
-        }
     )
 }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/AppTopTab.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/AppTopTab.kt
@@ -1,0 +1,60 @@
+package io.github.devriesl.raptormark.ui
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.*
+import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AppTopTab(
+    selectedIndex: Int,
+    sections: Array<AppSections>,
+    setSelectedSection: (AppSections) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        elevation = AppBarDefaults.TopAppBarElevation,
+        modifier = modifier
+    ) {
+        TabRow(
+            selectedTabIndex = selectedIndex,
+            backgroundColor = MaterialTheme.colors.surface,
+            indicator = {
+                TabRowDefaults.Indicator(
+                    color = MaterialTheme.colors.primary,
+                    modifier = Modifier.tabIndicatorOffset(it[selectedIndex])
+                )
+            },
+            divider = {}
+        ) {
+            sections.forEachIndexed { index, section ->
+                Tab(
+                    selected = index == selectedIndex,
+                    onClick = { setSelectedSection(section) },
+                    selectedContentColor = with(MaterialTheme.colors) { if (index == selectedIndex) primary else onSurface },
+                    modifier = Modifier.defaultMinSize(minHeight = 56.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(id = section.icon),
+                        contentDescription = stringResource(id = section.title)
+                    )
+                    Spacer(modifier = Modifier.height(0.dp))
+                    Text(
+                        text = stringResource(id = section.title),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = MaterialTheme.typography.caption.copy(textAlign = TextAlign.Center)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import io.github.devriesl.raptormark.R
@@ -29,7 +31,11 @@ fun RaptorApp(
     settingViewModel: SettingViewModel
 ) {
     RaptorMarkTheme {
-        val (selectedSection, setSelectedSection) = remember { mutableStateOf(AppSections.BENCHMARK) }
+        val (selectedSection, setSelectedSection) = rememberSaveable(stateSaver = enumSaver()) {
+            mutableStateOf(
+                AppSections.BENCHMARK
+            )
+        }
         val sections = AppSections.values()
         val selectedIndex by remember(selectedSection) {
             derivedStateOf { sections.indexOf(selectedSection) }
@@ -69,3 +75,8 @@ enum class AppSections(
     HISTORY(R.string.history_page_title, R.drawable.ic_history_tab),
     SETTING(R.string.setting_page_title, R.drawable.ic_setting_tab)
 }
+
+inline fun <reified Type : Enum<Type>> enumSaver() = Saver<Type, String>(
+    save = { it.name },
+    restore = { enumValueOf<Type>(it) }
+)

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import io.github.devriesl.raptormark.R
 import io.github.devriesl.raptormark.ui.benchmark.BenchmarkContent
@@ -33,6 +34,7 @@ fun RaptorApp(
         val selectedIndex by remember(selectedSection) {
             derivedStateOf { sections.indexOf(selectedSection) }
         }
+        val saveableStateHolder = rememberSaveableStateHolder()
         Scaffold(
             topBar = {
                 Column {
@@ -46,10 +48,12 @@ fun RaptorApp(
             },
             content = { scaffoldPadding ->
                 Box(modifier = Modifier.padding(scaffoldPadding)) {
-                    when (selectedSection) {
-                        AppSections.BENCHMARK -> BenchmarkContent(benchmarkViewModel)
-                        AppSections.HISTORY -> HistoryContent(historyViewModel)
-                        AppSections.SETTING -> SettingContent(settingViewModel)
+                    saveableStateHolder.SaveableStateProvider(selectedSection) {
+                        when (selectedSection) {
+                            AppSections.BENCHMARK -> BenchmarkContent(benchmarkViewModel)
+                            AppSections.HISTORY -> HistoryContent(historyViewModel)
+                            AppSections.SETTING -> SettingContent(settingViewModel)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
@@ -2,13 +2,16 @@ package io.github.devriesl.raptormark.ui
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.material.Scaffold
-import androidx.compose.material.rememberScaffoldState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import com.google.accompanist.insets.ProvideWindowInsets
+import androidx.compose.ui.Modifier
 import io.github.devriesl.raptormark.R
 import io.github.devriesl.raptormark.ui.benchmark.BenchmarkContent
 import io.github.devriesl.raptormark.ui.history.HistoryContent
@@ -17,7 +20,6 @@ import io.github.devriesl.raptormark.ui.theme.RaptorMarkTheme
 import io.github.devriesl.raptormark.viewmodels.BenchmarkViewModel
 import io.github.devriesl.raptormark.viewmodels.HistoryViewModel
 import io.github.devriesl.raptormark.viewmodels.SettingViewModel
-import kotlinx.coroutines.launch
 
 @Composable
 fun RaptorApp(
@@ -25,39 +27,33 @@ fun RaptorApp(
     historyViewModel: HistoryViewModel,
     settingViewModel: SettingViewModel
 ) {
-    ProvideWindowInsets {
-        RaptorMarkTheme {
-            val (selectedSection, setSelectedSection) = remember { mutableStateOf(AppSections.BENCHMARK) }
-            val sections = AppSections.values()
-            val selectedSectionIndex = sections.indexOfFirst { it == selectedSection }
-
-            val coroutineScope = rememberCoroutineScope()
-            val scaffoldState = rememberScaffoldState()
-
-            Scaffold(
-                scaffoldState = scaffoldState,
-                topBar = {
-                    AppTopBar(
-                        openDrawer = { coroutineScope.launch { scaffoldState.drawerState.open() } }
-                    )
-                },
-                drawerContent = {
-                    AppDrawer(
-                        selectedSectionIndex = selectedSectionIndex,
+    RaptorMarkTheme {
+        val (selectedSection, setSelectedSection) = remember { mutableStateOf(AppSections.BENCHMARK) }
+        val sections = AppSections.values()
+        val selectedIndex by remember(selectedSection) {
+            derivedStateOf { sections.indexOf(selectedSection) }
+        }
+        Scaffold(
+            topBar = {
+                Column {
+                    AppTopBar()
+                    AppTopTab(
+                        selectedIndex = selectedIndex,
                         sections = sections,
-                        setSelectedSection = setSelectedSection,
-                        closeDrawer = { coroutineScope.launch { scaffoldState.drawerState.close() } }
+                        setSelectedSection = setSelectedSection
                     )
-                },
-                content = {
+                }
+            },
+            content = { scaffoldPadding ->
+                Box(modifier = Modifier.padding(scaffoldPadding)) {
                     when (selectedSection) {
                         AppSections.BENCHMARK -> BenchmarkContent(benchmarkViewModel)
                         AppSections.HISTORY -> HistoryContent(historyViewModel)
                         AppSections.SETTING -> SettingContent(settingViewModel)
                     }
                 }
-            )
-        }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/benchmark/TestItem.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/benchmark/TestItem.kt
@@ -2,8 +2,9 @@ package io.github.devriesl.raptormark.ui.benchmark
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -17,9 +18,23 @@ fun TestItem(
     showLatency: Boolean,
     latency: Int?
 ) {
-    Column(
+    var twoLine by remember {
+        mutableStateOf(false)
+    }
+    val lineCount = when {
+        !showLatency && !twoLine -> 1
+        !showLatency || !twoLine -> 2
+        else -> 3
+    }
+    val minHeight = when (lineCount) {
+        1 -> 48.dp
+        2 -> 64.dp
+        else -> 88.dp
+    }
+    Box(
         modifier = Modifier
-            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .padding(horizontal = 16.dp)
+            .defaultMinSize(minHeight = minHeight)
             .fillMaxWidth()
     ) {
         val bandwidthText = if (bandwidth != null) {
@@ -27,15 +42,30 @@ fun TestItem(
         } else {
             String()
         }
-        Row {
+
+        Row(
+            modifier = Modifier.run {
+                if (twoLine || showLatency) {
+                    paddingFromBaseline(28.dp)
+                } else {
+                    align(Alignment.CenterStart)
+                }
+            }
+        ) {
             Text(
                 text = stringResource(title),
+                style = MaterialTheme.typography.subtitle1,
+                onTextLayout = {
+                    twoLine = it.lineCount > 1
+                },
                 modifier = Modifier.weight(1f)
             )
             Text(
                 text = bandwidthText,
-                modifier = Modifier.weight(2f),
-                textAlign = TextAlign.End
+                textAlign = TextAlign.End,
+                modifier = Modifier
+                    .weight(2f)
+                    .alignByBaseline()
             )
         }
         if (showLatency) {
@@ -44,18 +74,23 @@ fun TestItem(
             } else {
                 String()
             }
-
-            Spacer(Modifier.height(4.dp))
-            Row {
-                Text(
-                    text = stringResource(id = R.string.rand_4n_lat_title),
-                    modifier = Modifier.weight(1f)
-                )
-                Text(
-                    text = latencyText,
-                    modifier = Modifier.weight(2f),
-                    textAlign = TextAlign.End
-                )
+            Row(
+                modifier = Modifier.paddingFromBaseline(if (twoLine) 68.dp else 48.dp)
+            ) {
+                CompositionLocalProvider(
+                    LocalTextStyle provides MaterialTheme.typography.body2,
+                    LocalContentAlpha provides ContentAlpha.medium
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.rand_4n_lat_title),
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = latencyText,
+                        modifier = Modifier.weight(2f),
+                        textAlign = TextAlign.End
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/AboutInfoDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/AboutInfoDialog.kt
@@ -4,9 +4,10 @@ import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -37,11 +38,25 @@ fun AboutInfoDialog(
                 .fillMaxWidth()
                 .wrapContentHeight()
         ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = stringResource(title))
-                Divider(Modifier.padding(vertical = 8.dp))
+            Column {
+
                 Text(
-                    buildAnnotatedString {
+                    text = stringResource(title),
+                    style = MaterialTheme.typography.h6,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 16.dp)
+                        .defaultMinSize(minHeight = 40.dp)
+                        .wrapContentHeight(Alignment.Bottom)
+                )
+                fun Modifier.normalTextModifier(): Modifier {
+                    return Modifier
+                        .padding(horizontal = 16.dp)
+                        .then(this)
+                }
+
+                Text(
+                    text = buildAnnotatedString {
                         append(stringResource(R.string.app_name))
                         append(" ")
                         append(stringResource(R.string.about_version_text))
@@ -51,11 +66,12 @@ fun AboutInfoDialog(
                         ) {
                             append(BuildConfig.VERSION_NAME)
                         }
-                    }
+                    },
+                    modifier = Modifier.normalTextModifier()
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    buildAnnotatedString {
+                    text = buildAnnotatedString {
                         append(stringResource(R.string.about_author_text))
                         append(" ")
                         withStyle(
@@ -63,18 +79,35 @@ fun AboutInfoDialog(
                         ) {
                             append(stringResource(R.string.about_author_name))
                         }
-                    }
+                    },
+                    modifier = Modifier.normalTextModifier()
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(4.dp))
+
+                fun Modifier.clickableModifier(
+                    onClick: () -> Unit
+                ): Modifier {
+                    return Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onClick)
+                        .padding(
+                            vertical = 4.dp,
+                            horizontal = 16.dp
+                        )
+                        .then(this)
+                }
+
                 Text(
                     text = emailAddress,
-                    modifier = Modifier.clickable { openEmail(context, emailAddress) }
+                    modifier = Modifier
+                        .clickableModifier { openEmail(context, emailAddress) }
                 )
-                Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = stringResource(R.string.about_author_weibo),
-                    modifier = Modifier.clickable { openWeiboUser(context, uidValue) }
+                    modifier = Modifier
+                        .clickableModifier { openWeiboUser(context, uidValue) }
                 )
+                Spacer(modifier = Modifier.height(12.dp))
             }
         }
     }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/AboutInfoDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/AboutInfoDialog.kt
@@ -5,7 +5,6 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Divider
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -33,7 +32,7 @@ fun AboutInfoDialog(
     val emailAddress = stringResource(R.string.about_author_email)
 
     Dialog(onDismissRequest = { closeDialog(itemIndex, null) }) {
-        Surface(
+        DialogContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/DialogContent.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/DialogContent.kt
@@ -1,0 +1,20 @@
+package io.github.devriesl.raptormark.ui.setting
+
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DialogContent(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Card(
+        elevation = 16.dp,
+        shape = MaterialTheme.shapes.small,
+        modifier = modifier,
+        content = content
+    )
+}

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SettingContent.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SettingContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -28,7 +27,6 @@ fun SettingContent(
                     data = data,
                     openDialog = { settingViewModel.openDialog(settingItem) }
                 )
-                Divider()
             }
         }
 

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SettingItem.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SettingItem.kt
@@ -2,11 +2,8 @@ package io.github.devriesl.raptormark.ui.setting
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -21,26 +18,32 @@ fun SettingItem(
     data: String,
     openDialog: () -> Unit
 ) {
-    Column(
+    Box(
         modifier = Modifier
             .clickable(onClick = openDialog)
-            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .padding(horizontal = 16.dp)
+            .defaultMinSize(minHeight = 64.dp)
             .fillMaxWidth()
     ) {
-        Row {
+        Row(modifier = Modifier.paddingFromBaseline(28.dp)) {
             Text(
                 text = stringResource(title),
+                style = MaterialTheme.typography.subtitle1,
                 modifier = Modifier.weight(1f)
             )
+            Spacer(modifier = Modifier.width(28.dp))
             Text(
                 text = data,
-                modifier = Modifier.weight(1f),
-                textAlign = TextAlign.End
+                color = LocalContentColor.current.copy(ContentAlpha.medium),
+                textAlign = TextAlign.End,
+                modifier = Modifier.defaultMinSize(40.dp),
             )
         }
         Text(
             text = stringResource(desc),
-            fontSize = 14.sp
+            style = MaterialTheme.typography.body2,
+            color = LocalContentColor.current.copy(ContentAlpha.medium),
+            modifier = Modifier.paddingFromBaseline(48.dp)
         )
     }
 }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SingleChoiceDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SingleChoiceDialog.kt
@@ -2,15 +2,14 @@ package io.github.devriesl.raptormark.ui.setting
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -19,6 +18,7 @@ import androidx.compose.ui.window.Dialog
 @Composable
 fun SingleChoiceDialog(
     @StringRes title: Int,
+    defaultChoice: String,
     choiceList: ArrayList<String>,
     itemIndex: Int,
     closeDialog: (Int, String?) -> Unit,
@@ -29,18 +29,40 @@ fun SingleChoiceDialog(
                 .fillMaxWidth()
                 .wrapContentHeight()
         ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = stringResource(title))
-                Divider(Modifier.padding(top = 8.dp))
+            Column {
+                Text(
+                    text = stringResource(title),
+                    style = MaterialTheme.typography.h6,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 8.dp)
+                        .defaultMinSize(minHeight = 40.dp)
+                        .wrapContentHeight(Alignment.Bottom)
+                )
                 LazyColumn(modifier = Modifier.wrapContentHeight()) {
                     items(choiceList) { choice ->
-                        Text(text = choice, Modifier
-                            .clickable { closeDialog(itemIndex, choice) }
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp))
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillParentMaxWidth()
+                                .defaultMinSize(minHeight = 48.dp)
+                                .clickable { closeDialog(itemIndex, choice) }
+                        ) {
+                            RadioButton(
+                                selected = defaultChoice == choice,
+                                onClick = null,
+                                modifier = Modifier.padding(
+                                    start = 16.dp,
+                                    end = 16.dp
+                                )
+                            )
+                            Text(text = choice)
+                        }
                     }
                 }
+                Spacer(modifier = Modifier.height(16.dp))
             }
+
         }
     }
 }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SingleChoiceDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/SingleChoiceDialog.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -25,7 +24,7 @@ fun SingleChoiceDialog(
     closeDialog: (Int, String?) -> Unit,
 ) {
     Dialog(onDismissRequest = { closeDialog(itemIndex, null) }) {
-        Surface(
+        DialogContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
@@ -23,7 +23,7 @@ fun TargetPathDialog(
         var textFieldValue by remember { mutableStateOf(TextFieldValue(customValue)) }
         val selectCustomPath = mutableStateOf(customValue.isNotEmpty())
 
-        Surface(
+        DialogContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
@@ -31,7 +31,7 @@ fun TargetPathDialog(
         val inputService = LocalTextInputService.current
         LaunchedEffect(key1 = selectCustomPath.value) {
             if (selectCustomPath.value) {
-                delay(showSoftKeyboardDelayTime)
+                delay(300)
                 inputService?.showSoftwareKeyboard()
                 focusRequester.requestFocus()
             }else {

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
@@ -31,7 +31,7 @@ fun TargetPathDialog(
         val inputService = LocalTextInputService.current
         LaunchedEffect(key1 = selectCustomPath.value) {
             if (selectCustomPath.value) {
-                delay(300)
+                delay(showSoftKeyboardDelayTime)
                 inputService?.showSoftwareKeyboard()
                 focusRequester.requestFocus()
             }else {

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
@@ -31,7 +31,7 @@ fun TargetPathDialog(
         val inputService = LocalTextInputService.current
         LaunchedEffect(key1 = selectCustomPath.value) {
             if (selectCustomPath.value) {
-                delay(300)
+                delay(TextInputDialogDefault.SHOW_SOFT_KEYBOARD_DELAY_TIME)
                 inputService?.showSoftwareKeyboard()
                 focusRequester.requestFocus()
             }else {

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
@@ -1,16 +1,21 @@
 package io.github.devriesl.raptormark.ui.setting
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.github.devriesl.raptormark.R
+import kotlinx.coroutines.delay
 
 @Composable
 fun TargetPathDialog(
@@ -21,62 +26,88 @@ fun TargetPathDialog(
 ) {
     Dialog(onDismissRequest = { closeDialog(itemIndex, null) }) {
         var textFieldValue by remember { mutableStateOf(TextFieldValue(customValue)) }
-        val selectCustomPath = mutableStateOf(customValue.isNotEmpty())
-
+        val selectCustomPath = remember { mutableStateOf(customValue.isNotEmpty()) }
+        val focusRequester = remember { FocusRequester() }
+        val inputService = LocalTextInputService.current
+        LaunchedEffect(key1 = selectCustomPath.value) {
+            if (selectCustomPath.value) {
+                delay(300)
+                inputService?.showSoftwareKeyboard()
+                focusRequester.requestFocus()
+            }else {
+                inputService?.hideSoftwareKeyboard()
+            }
+        }
         DialogContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
         ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = stringResource(title))
-                Divider(Modifier.padding(vertical = 8.dp))
+            Column {
+                Text(
+                    text = stringResource(title),
+                    style = MaterialTheme.typography.h6,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 8.dp)
+                        .defaultMinSize(minHeight = 40.dp)
+                        .wrapContentHeight(Alignment.Bottom)
+                )
                 Row(
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .defaultMinSize(minHeight = 48.dp)
+                        .fillMaxWidth()
+                        .clickable { selectCustomPath.value = false }
                 ) {
                     RadioButton(
                         selected = !selectCustomPath.value,
-                        onClick = { selectCustomPath.value = false })
-                    Spacer(modifier = Modifier.width(8.dp))
+                        onClick = null,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
                     Text(stringResource(R.string.target_path_default))
                 }
+                Spacer(modifier = Modifier.height(8.dp))
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     RadioButton(
                         selected = selectCustomPath.value,
-                        onClick = { selectCustomPath.value = true })
+                        onClick = { selectCustomPath.value = true },
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
                     OutlinedTextField(
                         value = textFieldValue,
-                        modifier = Modifier
-                            .padding(8.dp)
-                            .fillMaxWidth(),
                         placeholder = { Text(stringResource(R.string.target_path_custom)) },
                         onValueChange = { textFieldValue = it },
-                        enabled = selectCustomPath.value
+                        enabled = selectCustomPath.value,
+                        modifier = Modifier
+                            .padding(end = 16.dp)
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester),
                     )
                 }
-                Divider(Modifier.padding(vertical = 8.dp))
-                Row {
-                    Button(
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                ) {
+                    TextButton(
                         onClick = { closeDialog(itemIndex, null) },
                         modifier = Modifier
-                            .weight(1f)
-                            .padding(horizontal = 8.dp)
+                            .padding(end = 8.dp)
                     ) {
                         Text(stringResource(R.string.dismiss_button_content))
                     }
-                    Button(
+                    TextButton(
                         onClick = {
                             if (selectCustomPath.value) {
                                 closeDialog(itemIndex, textFieldValue.text)
                             } else {
                                 closeDialog(itemIndex, String())
                             }
-                        },
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(horizontal = 8.dp)
+                        }
                     ) {
                         Text(stringResource(R.string.apply_button_content))
                     }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TargetPathDialog.kt
@@ -34,7 +34,7 @@ fun TargetPathDialog(
                 delay(TextInputDialogDefault.SHOW_SOFT_KEYBOARD_DELAY_TIME)
                 inputService?.showSoftwareKeyboard()
                 focusRequester.requestFocus()
-            }else {
+            } else {
                 inputService?.hideSoftwareKeyboard()
             }
         }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
@@ -100,7 +100,7 @@ fun TextInputDialog(
                             }
                         },
                         modifier = Modifier
-                            .padding(horizontal = 8.dp)
+                            .padding(end = 8.dp)
                     ) {
                         Text(stringResource(R.string.apply_button_content))
                     }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
@@ -19,6 +19,10 @@ import androidx.compose.ui.window.Dialog
 import io.github.devriesl.raptormark.R
 import kotlinx.coroutines.delay
 
+internal object TextInputDialogDefault {
+    const val SHOW_SOFT_KEYBOARD_DELAY_TIME = 300L
+}
+
 @Composable
 fun TextInputDialog(
     @StringRes title: Int,
@@ -43,7 +47,7 @@ fun TextInputDialog(
         val inputService = LocalTextInputService.current
         LaunchedEffect(Unit) {
             //Wait a little time to make sure the input service wakes up the keyboard
-            delay(300)
+            delay(TextInputDialogDefault.SHOW_SOFT_KEYBOARD_DELAY_TIME)
             inputService?.showSoftwareKeyboard()
             focusRequester.requestFocus()
         }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
@@ -19,8 +19,6 @@ import androidx.compose.ui.window.Dialog
 import io.github.devriesl.raptormark.R
 import kotlinx.coroutines.delay
 
-internal const val showSoftKeyboardDelayTime = 300L
-
 @Composable
 fun TextInputDialog(
     @StringRes title: Int,
@@ -45,7 +43,7 @@ fun TextInputDialog(
         val inputService = LocalTextInputService.current
         LaunchedEffect(Unit) {
             //Wait a little time to make sure the input service wakes up the keyboard
-            delay(showSoftKeyboardDelayTime)
+            delay(300)
             inputService?.showSoftwareKeyboard()
             focusRequester.requestFocus()
         }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.window.Dialog
 import io.github.devriesl.raptormark.R
 import kotlinx.coroutines.delay
 
+internal const val showSoftKeyboardDelayTime = 300L
+
 @Composable
 fun TextInputDialog(
     @StringRes title: Int,
@@ -43,7 +45,7 @@ fun TextInputDialog(
         val inputService = LocalTextInputService.current
         LaunchedEffect(Unit) {
             //Wait a little time to make sure the input service wakes up the keyboard
-            delay(300)
+            delay(showSoftKeyboardDelayTime)
             inputService?.showSoftwareKeyboard()
             focusRequester.requestFocus()
         }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/setting/TextInputDialog.kt
@@ -25,7 +25,7 @@ fun TextInputDialog(
     Dialog(onDismissRequest = { closeDialog(itemIndex, null) }) {
         var textFieldValue by remember { mutableStateOf(TextFieldValue(currentValue)) }
 
-        Surface(
+        DialogContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()


### PR DESCRIPTION
## Update all UI designs for the app. 
**The new design refers to [material design official documentation ](https://material.io) as much as possible**

### 1. **Home Page**

- Replace the drawer with the top tab, and in the future use Navigation Rail(medium) or DawerButton(large) for large screens

![Home Page](https://user-images.githubusercontent.com/26089739/153742964-3c41713b-72b5-4278-9759-2627580851e9.jpg)

### 2. **Bench Page**

- Update item design refers to [OneLineItem, TwoLineItem, ThreeLineItem](https://material.io/components/lists#specs)

![Bench Page](https://user-images.githubusercontent.com/26089739/153743090-4bf13f34-a2d2-4bb5-86bb-1a457c5d31bd.jpg)

![Bench Page 2](https://user-images.githubusercontent.com/26089739/153743363-b96a9871-4ec1-4992-b9e0-06113cd7ca53.jpg)

### 3. **History Page**

- Update item design refers to [Expandable item](https://material.io/components/lists#specs). In the future, after updating to Compose 1.1, an expand/shirink animation will be added by using AnimateVisibility

![History Page](https://user-images.githubusercontent.com/26089739/153743176-6d2a4c47-8114-43c2-bfc2-e1b3d444e92d.jpg)

### 4. **Setting Page**

- Update item design referes to [TwoLineItem](https://material.io/components/lists#specs)

![Setting Page](https://user-images.githubusercontent.com/26089739/153743384-b57693aa-ebdf-4607-997d-b9eb1835657a.jpg)

- Update TargetPathDialog design referes to [Dialog](https://material.io/components/dialogs#specs)

![Target path dialog](https://user-images.githubusercontent.com/26089739/153743424-82e500f4-59d2-489e-aad3-4d6673438b49.jpg)

- Update SingleChoiceDialog deisgn referes to [Single choice dialog](https://material.io/components/dialogs#specs)

![Single choice dialog](https://user-images.githubusercontent.com/26089739/153743498-221f4df5-37b4-4893-9e91-b09742cf29df.jpg)

- Update TextInputDialog design referes to [Dialog](https://material.io/components/dialogs#specs)

![Text input dialog](https://user-images.githubusercontent.com/26089739/153743522-993f7faf-8a76-49da-83d6-a0fec688f141.jpg)

- Update AboutDialog design referes to [Dialog](https://material.io/components/dialogs#specs)
![About dialog](https://user-images.githubusercontent.com/26089739/153743537-3fd95c93-7bc4-4dbd-8e81-706171bcc9e8.jpg)


