### PR TITLE
Update contributors dialog design

### DIFF
--- a/app/src/main/java/io/github/devriesl/raptormark/data/network/LoadState.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/data/network/LoadState.kt
@@ -1,0 +1,7 @@
+package io.github.devriesl.raptormark.data.network
+
+enum class LoadState {
+    Loading,
+    Failed,
+    NotLoad
+}

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/widget/ContributorsDialog.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/widget/ContributorsDialog.kt
@@ -1,18 +1,25 @@
 package io.github.devriesl.raptormark.ui.widget
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import coil.compose.AsyncImage
 import io.github.devriesl.raptormark.R
+import io.github.devriesl.raptormark.data.network.LoadState
 import io.github.devriesl.raptormark.viewmodels.MainViewModel
 
 @Composable
@@ -26,30 +33,101 @@ fun ContributorsDialog(
                 .fillMaxWidth()
                 .wrapContentHeight()
         ) {
-            LazyColumn(
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .height(480.dp),
-                contentPadding = PaddingValues(vertical = 16.dp)
+            val contributorListState = rememberLazyListState()
+            val isListOnTop by remember {
+                derivedStateOf { contributorListState.firstVisibleItemIndex == 0 && contributorListState.firstVisibleItemScrollOffset == 0 }
+            }
+            Column(
+                modifier = Modifier.height(480.dp)
             ) {
-                item {
+                Box {
                     Text(
                         text = stringResource(id = R.string.contributors_dialog_title),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                         style = MaterialTheme.typography.h6,
                         modifier = Modifier
-                            .defaultMinSize(minHeight = 40.dp)
-                            .wrapContentHeight(Alignment.Top)
+                            .height(64.dp)
+                            .paddingFromBaseline(40.dp)
+                            .padding(horizontal = 16.dp)
+                    )
+                    val targetThickness by animateDpAsState(
+                        targetValue = if (isListOnTop) {
+                            Dp.Unspecified
+                        } else {
+                            1.dp
+                        }
+                    )
+                    Divider(
+                        thickness = targetThickness,
+                        modifier = Modifier.align(Alignment.BottomStart)
                     )
                 }
-                items(mainViewModel.contributorList) { contributor ->
-                    Row(Modifier.height(64.dp)) {
-                        AsyncImage(
-                            modifier = Modifier.padding(4.dp),
-                            model = contributor.avatarUrl,
-                            contentDescription = contributor.userName
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = contributor.userName)
+                LazyColumn(
+                    state = contributorListState,
+                    contentPadding = PaddingValues(bottom = 16.dp),
+                    modifier = Modifier
+                        .weight(1f)
+                ) {
+                    if (mainViewModel.loadState != LoadState.NotLoad) {
+                        item(
+                            key = "load_button",
+                            contentType = "load_button"
+                        ) {
+                            Button(
+                                onClick = { mainViewModel.updateContributors() },
+                                enabled = mainViewModel.loadState == LoadState.Failed,
+                                modifier = Modifier
+                                    .fillParentMaxWidth()
+                                    .wrapContentWidth(Alignment.CenterHorizontally)
+                                    .animateContentSize()
+                            ) {
+                                val isLoading = mainViewModel.loadState == LoadState.Loading
+                                if (isLoading) {
+                                    CircularProgressIndicator(
+                                        strokeWidth = 2.dp,
+                                        modifier = Modifier
+                                            .padding(end = ButtonDefaults.IconSpacing)
+                                            .size(ButtonDefaults.IconSize)
+                                    )
+                                }
+                                Text(
+                                    text = if (isLoading) {
+                                        stringResource(R.string.state_loading_description)
+                                    } else {
+                                        stringResource(R.string.state_loading_failed_click_retry_description)
+                                    }
+                                )
+                            }
+                        }
+                    }
+                    items(
+                        items = mainViewModel.contributorList,
+                        contentType = { "contributor" },
+                        key = { contributor -> contributor.id }
+                    ) { contributor ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .height(56.dp)
+                                .fillParentMaxWidth()
+                                .padding(horizontal = 16.dp)
+                        ) {
+                            AsyncImage(
+                                modifier = Modifier
+                                    .padding(vertical = 8.dp)
+                                    .size(40.dp)
+                                    .clip(RoundedCornerShape(50)),
+                                model = contributor.avatarUrl,
+                                contentDescription = contributor.userName
+                            )
+                            Spacer(modifier = Modifier.width(16.dp))
+                            Text(
+                                text = contributor.userName,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/github/devriesl/raptormark/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/viewmodels/MainViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.devriesl.raptormark.data.network.Contributor
 import io.github.devriesl.raptormark.data.network.GitHubService
+import io.github.devriesl.raptormark.data.network.LoadState
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,12 +18,22 @@ class MainViewModel @Inject constructor(
     private val gitHubService: GitHubService
 ) : ViewModel() {
     var contributorList by mutableStateOf(emptyList<Contributor>())
+        private set
+
+    var loadState by mutableStateOf(LoadState.NotLoad)
+        private set
 
     fun updateContributors() {
-        viewModelScope.launch {
+        viewModelScope.launch(
+            context = CoroutineExceptionHandler { _, _ ->
+                loadState = LoadState.Failed
+            }
+        ) {
+            loadState = LoadState.Loading
             contributorList = gitHubService.getContributors().sortedBy {
                 it.contributions
             }
+            loadState = LoadState.NotLoad
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,5 +56,7 @@
     <string name="about_author_email">therkduan@gmail.com</string>
     <string name="about_author_weibo">https://weibo.com/2213561393</string>
     <string name="about_author_weibo_uid">2213561393</string>
+    <string name="state_loading_description">loading</string>
+    <string name="state_loading_failed_click_retry_description">loading failed, click to retry</string>
 
 </resources>


### PR DESCRIPTION
1. Update contributors dialog design refers to [Dialog](https://material.io/components/dialogs#specs) and [SingleLineListItem](https://material.io/components/lists#specs)
2. Catch network error and show a retry button, if contributorList fetch failed
![retry button](https://user-images.githubusercontent.com/26089739/178663128-d4c17d29-57d0-447b-a788-278304886995.jpg)

