### PR TITLE
Update HomeScreen design refers to Adaptive Design

### DIFF
--- a/app/src/main/java/io/github/devriesl/raptormark/ui/AppDrawer.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/AppDrawer.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.*
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -23,17 +23,16 @@ fun AppDrawer(
     selectedSectionIndex: Int,
     sections: Array<AppSections>,
     setSelectedSection: (AppSections) -> Unit,
-    closeDrawer: () -> Unit
+    modifier: Modifier = Modifier
 ) {
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(sections) { section ->
+    LazyColumn(modifier = Modifier.then(modifier)) {
+        itemsIndexed(sections) { index, section ->
             DrawerButton(
                 icon = section.icon,
                 title = section.title,
-                isSelected = selectedSectionIndex == sections.indexOf(section),
+                isSelected = selectedSectionIndex == index,
                 action = {
                     setSelectedSection(section)
-                    closeDrawer()
                 }
             )
         }

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/AppNavigationRail.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/AppNavigationRail.kt
@@ -1,0 +1,37 @@
+package io.github.devriesl.raptormark.ui
+
+import androidx.compose.material.Icon
+import androidx.compose.material.NavigationRailItem
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+
+@Composable
+fun AppNavigationRail(
+    selectedSectionIndex: Int,
+    sections: Array<AppSections>,
+    setSelectedSection: (AppSections) -> Unit,
+) {
+    sections.forEachIndexed { index, section ->
+        val labelString = stringResource(id = section.title)
+        NavigationRailItem(
+            selected = index == selectedSectionIndex,
+            icon = {
+                Icon(
+                    painter = painterResource(id = section.icon),
+                    contentDescription = labelString
+                )
+            },
+            label = {
+                Text(
+                    text = labelString,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            },
+            onClick = { setSelectedSection(section) }
+        )
+    }
+}

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/RaptorApp.kt
@@ -2,9 +2,7 @@ package io.github.devriesl.raptormark.ui
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -15,6 +13,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import io.github.devriesl.raptormark.R
 import io.github.devriesl.raptormark.ui.benchmark.BenchmarkContent
 import io.github.devriesl.raptormark.ui.history.HistoryContent
@@ -43,29 +42,57 @@ fun RaptorApp(
             derivedStateOf { sections.indexOf(selectedSection) }
         }
         val saveableStateHolder = rememberSaveableStateHolder()
-        Scaffold(
-            topBar = {
-                Column {
-                    AppTopBar(mainViewModel)
-                    AppTopTab(
-                        selectedIndex = selectedIndex,
-                        sections = sections,
-                        setSelectedSection = setSelectedSection
-                    )
-                }
-            },
-            content = { scaffoldPadding ->
-                Box(modifier = Modifier.padding(scaffoldPadding)) {
-                    saveableStateHolder.SaveableStateProvider(selectedSection) {
-                        when (selectedSection) {
-                            AppSections.BENCHMARK -> BenchmarkContent(benchmarkViewModel)
-                            AppSections.HISTORY -> HistoryContent(historyViewModel)
-                            AppSections.SETTING -> SettingContent(settingViewModel)
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val widthClass = rememberSizeClass(size = maxWidth)
+            Scaffold(
+                topBar = {
+                    Column {
+                        AppTopBar(mainViewModel)
+                        if (widthClass == SizeClass.Compact) {
+                            AppTopTab(
+                                selectedIndex = selectedIndex,
+                                sections = sections,
+                                setSelectedSection = setSelectedSection
+                            )
+                        }
+                    }
+                },
+                content = { scaffoldPadding ->
+                    Row(modifier = Modifier.padding(scaffoldPadding)) {
+                        if (widthClass != SizeClass.Compact) {
+                            NavigationRail(
+                                backgroundColor = MaterialTheme.colors.surface
+                            ) {
+                                if (widthClass == SizeClass.Expanded) {
+                                    AppDrawer(
+                                        selectedSectionIndex = selectedIndex,
+                                        sections = sections,
+                                        setSelectedSection = setSelectedSection,
+                                        modifier = Modifier
+                                            .width(280.dp)
+                                    )
+                                } else {
+                                    AppNavigationRail(
+                                        selectedSectionIndex = selectedIndex,
+                                        sections = sections,
+                                        setSelectedSection = setSelectedSection,
+                                    )
+                                }
+                            }
+                        }
+                        Box {
+                            saveableStateHolder.SaveableStateProvider(selectedSection) {
+                                when (selectedSection) {
+                                    AppSections.BENCHMARK -> BenchmarkContent(benchmarkViewModel)
+                                    AppSections.HISTORY -> HistoryContent(historyViewModel)
+                                    AppSections.SETTING -> SettingContent(settingViewModel)
+                                }
+                            }
                         }
                     }
                 }
-            }
-        )
+            )
+        }
     }
 }
 

--- a/app/src/main/java/io/github/devriesl/raptormark/ui/SizeClass.kt
+++ b/app/src/main/java/io/github/devriesl/raptormark/ui/SizeClass.kt
@@ -1,0 +1,25 @@
+package io.github.devriesl.raptormark.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class SizeClass {
+    Compact,
+    Medium,
+    Expanded;
+
+    companion object {
+        fun from(size: Dp) = when {
+            size < 600.dp -> Compact
+            size < 840.dp -> Medium
+            else -> Expanded
+        }
+    }
+}
+
+@Composable
+fun rememberSizeClass(size: Dp) = remember(size) {
+    SizeClass.from(size)
+}


### PR DESCRIPTION
See [component adaption](https://m3.material.io/foundations/adaptive-design/large-screens/component-adaptation) and [Large Screen](https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes#specific-support)
1. 411dp (Compact use `Tab`)
![Compact](https://user-images.githubusercontent.com/26089739/178729448-99768602-0b2d-409f-93b3-0031c796964e.jpg)
2. 600dp (Medium use  `NavigationRail`)
![Medium](https://user-images.githubusercontent.com/26089739/178729711-1e7a8fb6-1eac-49d2-aa25-8b64d257439a.jpg)
3. 890dp (Expanded use `Drawer`)
![Expended](https://user-images.githubusercontent.com/26089739/178729789-69c3fda9-21ca-4165-928f-541c8d990d9c.jpg)

 